### PR TITLE
Adding a new feature for movie returns

### DIFF
--- a/app/models/rental.rb
+++ b/app/models/rental.rb
@@ -1,4 +1,6 @@
 class Rental < ApplicationRecord
     belongs_to :user
     belongs_to :movie
+
+    enum status: { rented: 0, delivered: 1 }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
     get :recommendations, on: :collection
     get :user_rented_movies, on: :collection
     post :rent, on: :member
+    post :return, on: :member
   end
 end

--- a/db/migrate/20230717184544_add_status_to_rentals.rb
+++ b/db/migrate/20230717184544_add_status_to_rentals.rb
@@ -1,0 +1,5 @@
+class AddStatusToRentals < ActiveRecord::Migration[7.0]
+  def change
+    add_column :rentals, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_17_170002) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_17_184544) do
   create_table "favorite_movies", id: false, force: :cascade do |t|
     t.integer "movie_id"
     t.integer "user_id"
@@ -33,6 +33,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_17_170002) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["movie_id"], name: "index_rentals_on_movie_id"
     t.index ["user_id", "movie_id"], name: "index_rentals_on_user_id_and_movie_id"
     t.index ["user_id"], name: "index_rentals_on_user_id"


### PR DESCRIPTION
### What Was Changed

1. Added a new endpoint for returning movies: Because once all movies were rented, there's no way to populate available_copies again(if not by rails console/DB)

### How To Test

1. Run `rails db:migrate` to create the new field.
2. Fetch for POST /movies/:id/return, you should be able to return all the rentals under that movie ID for your user.
**PS:** This feature was done for simplicity, in the ideal solution we would need quantity stored when renting and returning only one (or many) rentals using those quantities.